### PR TITLE
Fix publish workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,17 @@ jobs:
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'
-    - name: Publish if version has been updated
-      uses: pascalgn/npm-publish-action@4f4bf159e299f65d21cd1cbd96fc5d53228036df
-      with: # All of theses inputs are optional
-        tag_name: "%s"
-        tag_message: "%s"
-        commit_pattern: "^Release (\\S+)"
-      env: # More info about the environment variables in the README
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
+    - id: publish
+      uses: JS-DevTools/npm-publish@v4
+    - name: Create Release
+      if: ${{ steps.publish.outputs.type }}
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.publish.outputs.version }}
+        release_name: Release ${{ steps.publish.outputs.version }}
+        body: ${{ steps.publish.outputs.version }}
+        draft: false
+        prerelease: false


### PR DESCRIPTION
## Summary
- Update to JS-DevTools/npm-publish@v4
- Set node-version to 24 (trusted publishing requires npm >=11.5.1)
- Add registry-url for OIDC
- Fix publish condition for v4
- Remove NPM_AUTH_TOKEN (using OIDC now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)